### PR TITLE
feat: harden runtime and add container tooling for MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution artifacts
+build/
+dist/
+*.egg-info/
+*.dxt
+
+# Environment & tooling
+.venv/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+
+# Node artifacts
+node_modules/
+
+# Misc
+.DS_Store
+*.log
+notebooks/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.7-labs
+
+ARG PYTHON_VERSION="3.11"
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG APP_VERSION=local
+
+COPY pyproject.toml README.md requirements.txt requirements-dev.txt uv.lock ./
+COPY src ./src
+
+RUN pip install --upgrade pip setuptools wheel \
+    && if [ "${APP_VERSION}" = "local" ]; then \
+         pip install --no-cache-dir -r requirements.txt; \
+       else \
+         pip install --no-cache-dir "iam-mcp-server==${APP_VERSION}"; \
+       fi \
+    && PYTHONPATH=/app/src python -c "import mcp_server_iam; print('MCP server module loaded successfully')"
+
+RUN useradd --create-home --home /home/iam iam \
+    && mkdir -p /data \
+    && chown -R iam:iam /data
+
+USER iam
+
+ENV IAM_DATA_ROOT=/data \
+    LOG_LEVEL=INFO \
+    MCP_TRANSPORT=stdio
+
+VOLUME ["/data"]
+
+ENV PYTHONPATH=/app/src${PYTHONPATH:+:$PYTHONPATH}
+
+ENTRYPOINT ["python", "-m", "mcp_server_iam"]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,68 @@ Get the latest pre-built DXT file from our GitHub releases:
 
 **[📥 Download Latest DXT →](https://github.com/alejandrogarcia-hub/iam-mcp-server/releases/latest)**
 
+### 🐳 Container Sidecar
+
+Build a self-contained image and run it alongside your MCP host:
+
+```bash
+# Build image using published wheel (set APP_VERSION to released tag)
+docker build --no-cache --build-arg APP_VERSION=2.1.0 -t iam-mcp-server:2.1.0 .
+
+# For local source builds, omit APP_VERSION or pass APP_VERSION=local
+docker build -t iam-mcp-server:dev .
+
+# Start the server with a writable data volume and required secrets
+docker run --rm \
+  --name iam-mcp-server \
+  -e RAPIDAPI_KEY=your_rapidapi_key \
+  -e LOG_LEVEL=INFO \
+  -e MCP_TRANSPORT=stdio \
+  -v $(pwd)/data:/data \
+  iam-mcp-server:2.1.0
+
+# OR
+docker run --rm -i \
+    -e RAPIDAPI_KEY="your-api-key-here" \
+    -e LOG_LEVEL=DEBUG \
+    -v $(pwd)/data:/data \
+    iam-mcp-server:dev
+
+# then initialize the server
+'{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"0.1.0","capabilities":{},"clientInfo":{"name":"my-client","version":"1.0.0"}},"id":1}'
+
+# acknowledge the server
+'{"jsonrpc":"2.0","method":"notifications/initialized","params":{"capabilities":{}}}'
+
+# list available tools
+'{"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 2}'
+
+# list available prompts
+'{"jsonrpc": "2.0", "method": "prompts/list", "params": {}, "id": 3}'
+```
+
+#### Test the container
+
+```bash
+echo '{"jsonrpc": "2.0", "method": "initialize", "params": {"protocolVersion": "0.1.0", "capabilities": {}, 
+  "clientInfo": {"name": "test", "version": "1.0.0"}}, "id": 1}' | docker run --rm -i iam-mcp-server:dev
+
+# List available tools
+echo '{"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 2}' | docker run --rm -i iam-mcp-server:dev
+
+# List available prompts
+echo '{"jsonrpc": "2.0", "method": "prompts/list", "params": {}, "id": 3}' | docker run --rm -i iam-mcp-server:dev
+```
+
+Key runtime environment variables:
+
+- `RAPIDAPI_KEY` / `RAPIDAPI_HOST` – credentials for the JSearch integration.
+- `IAM_DATA_ROOT` (defaults to `/data`) – location where resume meshes and exports are written.
+- `LOG_LEVEL` – structured JSON logs emitted via stdout.
+- `MCP_TRANSPORT` – keep `stdio` for sidecar usage or swap for another supported transport when needed.
+
+Attach the container to your MCP host by pointing the host’s configuration at the container entry point. Share the `/data` volume with the host if it needs direct access to generated artifacts.
+
 Look for `iam_mcp_server-[version].dxt` in the release assets.
 
 #### Installation in Claude Desktop

--- a/manifest.json
+++ b/manifest.json
@@ -67,7 +67,7 @@
         "platform",
         "num_jobs"
       ],
-      "text": "\n    # System / Instruction Prompt for LLM\n    You are a data-driven AI assistant, your task is to analyze the job market for the top 5 positions matching a given AI Engineer, optionally filtered by Zurich and Switzerland, and sourced from linkedin."
+      "text": "Generated at runtime. The server injects the user-provided role, optional location details, and platform preferences into a markdown workflow that guides the MCP host through planning, invoking the search_jobs tool, and summarising trends."
     },
     {
       "name": "save_jobs",
@@ -79,7 +79,7 @@
         "country",
         "num_jobs"
       ],
-      "text": "\n# System Instructions for Saving Job Search Results\n\nYou are tasked with saving job search results to a structured JSON file. Follow these instructions precisely:\n\n## File Location and Naming\n- **Directory**: Save to `/Users/username/jobs` directory\n- **Filename**: `2025-07-23_AI_Engineer_Zurich_Switzerland_5.json`"
+      "text": "Generated at runtime. Produces detailed JSON-saving instructions tailored to the provided directory, role, location, and result count, including validation steps and metadata requirements."
     },
     {
       "name": "mesh_resumes",
@@ -87,7 +87,7 @@
       "arguments": [
         "save_directory"
       ],
-      "text": "\n# System Instructions for Creating a Resume Mesh\nYou have been given multiple resumes (CVs) of the same person. Mesh them into one unified resume by applying the following rules:\n- Include every section from all the input resumes."
+      "text": "Generated at runtime. Instructs the MCP host to combine multiple resume sources into a unified markdown document saved in the requested directory with the configured mesh filename and timestamp."
     },
     {
       "name": "generate_resume",
@@ -98,7 +98,7 @@
         "company",
         "job_description"
       ],
-      "text": "\n    # System Instructions for Generating a Resume\n\n    Act like a seasoned career consultant and resume expert specializing in crafting tailor-made resumes for job seekers.\n    Your sole job now is to produce a Markdown resume that aligns perfectly with the `AI Engineer` Job Description (JD) at `Google`."
+      "text": "Generated at runtime. Crafts a structured resume prompt incorporating the provided role, company, and job description, and instructs the MCP host to persist the output in the supplied directory."
     },
     {
       "name": "generate_cover_letter",
@@ -109,7 +109,7 @@
         "company",
         "job_description"
       ],
-      "text": "\n# System Instructions for Generating a Cover Letter\nAct like a seasoned career consultant and cover letter expert specializing in crafting tailor-made cover letter for job seekers.\n- Create a compelling cover letter for the \"AI Engineer\" position at Google."
+      "text": "Generated at runtime. Produces a cover-letter workflow aligned with the supplied job context and directs the MCP host to save the rendered markdown in the specified directory."
     }
   ],
   "prompts_generated": true,

--- a/src/mcp_server_iam/__main__.py
+++ b/src/mcp_server_iam/__main__.py
@@ -1,9 +1,11 @@
 # src/mcp_server_iam/__main__.py
 from mcp_server_iam.config import settings
+from mcp_server_iam.logging import setup_logging
 from mcp_server_iam.server import mcp
 
 
 def main():
+    setup_logging(settings.log_level, include=["mcp"])
     mcp.run(transport=settings.transport)  # starts stdio server; blocks until exit
 
 

--- a/src/mcp_server_iam/logging.py
+++ b/src/mcp_server_iam/logging.py
@@ -1,0 +1,31 @@
+"""Application logging utilities."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+
+from pythonjsonlogger.json import JsonFormatter
+
+
+def setup_logging(level: int, *, include: Iterable[str] | None = None) -> None:
+    """Configure structured JSON logging for the application."""
+
+    handler = logging.StreamHandler()
+    formatter = JsonFormatter(
+        fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+        json_default=str,
+    )
+
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.setLevel(level)
+    root.addHandler(handler)
+
+    logging.captureWarnings(True)
+
+    if include:
+        for logger_name in include:
+            logging.getLogger(logger_name).setLevel(level)

--- a/src/mcp_server_iam/utils.py
+++ b/src/mcp_server_iam/utils.py
@@ -1,3 +1,20 @@
+from html import escape, unescape
+
+
+def sanitize_text(value: str | None, *, limit: int | None = None) -> str:
+    """Return a safely escaped representation of arbitrary text."""
+
+    if value is None:
+        return ""
+
+    text = unescape(str(value))
+
+    if limit is not None and limit > 0 and len(text) > limit:
+        text = text[:limit] + "\n...\n"
+
+    return escape(text, quote=True)
+
+
 def get_country_code(country_name: str) -> str:
     """
     Convert full country name to ISO_3166-1_alpha-2 code in lowercase.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,45 @@
+"""Tests for application configuration utilities."""
+
+from pathlib import Path
+
+import pytest
+
+from mcp_server_iam import config
+
+
+@pytest.fixture(autouse=True)
+def reset_settings_cache():
+    """Ensure settings cache is cleared between tests."""
+    config.get_settings.cache_clear()
+    try:
+        yield
+    finally:
+        config.get_settings.cache_clear()
+
+
+def test_resumes_dir_uses_configured_data_root(monkeypatch, tmp_path):
+    """Configured IAM_DATA_ROOT should control the resume storage location."""
+
+    monkeypatch.setenv("IAM_DATA_ROOT", str(tmp_path))
+
+    settings = config.get_settings()
+    resumes_path = Path(settings.resumes_dir)
+
+    assert resumes_path.is_dir()
+    assert resumes_path.parent == tmp_path.resolve()
+
+
+def test_resumes_dir_defaults_to_xdg_data_home(monkeypatch, tmp_path):
+    """When IAM_DATA_ROOT is unset, fall back to XDG_DATA_HOME."""
+
+    monkeypatch.delenv("IAM_DATA_ROOT", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+    settings = config.get_settings()
+    expected_root = (tmp_path / "iam-mcp-server").resolve()
+    expected = expected_root / "resumes"
+
+    resumes_path = Path(settings.resumes_dir)
+
+    assert resumes_path == expected
+    assert resumes_path.is_dir()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,22 @@
+"""Tests for structured logging configuration."""
+
+import logging
+
+from mcp_server_iam.logging import setup_logging
+
+
+def test_setup_logging_configures_root_handler():
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+
+    for handler in original_handlers:
+        root.removeHandler(handler)
+
+    try:
+        setup_logging(logging.INFO)
+        assert root.level == logging.INFO
+        assert len(root.handlers) == 1
+    finally:
+        root.handlers.clear()
+        for handler in original_handlers:
+            root.addHandler(handler)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,15 @@
+"""Regression tests for manifest metadata."""
+
+import json
+from pathlib import Path
+
+
+def test_manifest_prompts_are_runtime_described():
+    """Manifest prompt text should not contain hard-coded sample personas."""
+
+    manifest = json.loads(Path("manifest.json").read_text())
+
+    prompt_texts = [entry.get("text", "") for entry in manifest.get("prompts", [])]
+
+    assert all("Generated at runtime" in text for text in prompt_texts)
+    assert all("AI Engineer" not in text for text in prompt_texts)

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -301,9 +301,9 @@ class TestSearchJobs:
         # Assert
         assert len(result) == 1
         assert result[0]["job_id"] == "job1"
-        assert result[0]["title"] is None
-        assert result[0]["company"] is None
-        assert result[0]["location"] is None
+        assert result[0]["title"] == ""
+        assert result[0]["company"] == ""
+        assert result[0]["location"] == ""
         assert result[0]["description"] == ""
         assert result[0]["apply_link"] == "Not provided"
 
@@ -392,8 +392,10 @@ class TestSearchJobs:
 
         # Assert
         # The function currently passes through potentially dangerous content
-        assert result[0]["job_id"] == "<script>alert('xss')</script>"
-        assert result[0]["title"] == "<img src=x onerror=alert('xss')>"
+        assert "<" not in result[0]["job_id"]
+        assert "<" not in result[0]["title"]
+        assert "&lt;script" in result[0]["job_id"]
+        assert "&lt;img" in result[0]["title"]
 
     # ========== Network Error Tests ==========
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+"""Unit tests for utility helpers."""
+
+from mcp_server_iam.utils import sanitize_text
+
+
+def test_sanitize_text_escapes_html():
+    result = sanitize_text("<div>alert('hi')</div>")
+    assert result == "&lt;div&gt;alert(&#x27;hi&#x27;)&lt;/div&gt;"
+
+
+def test_sanitize_text_truncates_when_limit_exceeded():
+    text = "abcdef"
+    result = sanitize_text(text, limit=3)
+    assert result == "abc\n...\n"


### PR DESCRIPTION
  - add IAM_DATA_ROOT setting, relocate resume storage to user-writable paths
  - sanitize external job payloads and escape HTML before returning tool output
  - wire structured JSON logging and add instrumentation to job search lifecycle
  - refresh manifest prompt metadata to reflect runtime generation
  - document container sidecar workflow and add Dockerfile/.dockerignore
  - add pytest coverage for config, manifest, utils, logging, and sanitization
  - update docker test harnesses to speak MCP framing and pretty-print replies